### PR TITLE
Add UI for account archiving (Issue #11)

### DIFF
--- a/src/penny/api/accounts.py
+++ b/src/penny/api/accounts.py
@@ -47,6 +47,7 @@ def _account_to_dict(account: Account, transaction_count: int = 0) -> dict:
         "subaccounts": list(account.subaccounts.keys()),
         "transaction_count": transaction_count,
         "label": account.display_name or f"{account.bank} #{account.id}",
+        "hidden": account.hidden,
     }
 
 

--- a/src/penny/static/api.js
+++ b/src/penny/static/api.js
@@ -40,10 +40,12 @@ export const fetchMeta = async () => {
 
 /**
  * Fetch all accounts.
+ * @param {boolean} includeHidden - Include hidden accounts
  * @returns {Promise<{ accounts: object[] }>}
  */
-export const fetchAccounts = async () => {
-  const resp = await fetch('/api/accounts');
+export const fetchAccounts = async (includeHidden = false) => {
+  const params = includeHidden ? '?include_hidden=true' : '';
+  const resp = await fetch(`/api/accounts${params}`);
   return resp.json();
 };
 
@@ -98,6 +100,22 @@ export const recordBalanceSnapshot = async (accountId, snapshot) => {
   if (!resp.ok) {
     const error = await resp.json();
     throw new Error(error.detail || 'Failed to record balance');
+  }
+  return resp.json();
+};
+
+/**
+ * Delete (hide) an account.
+ * @param {number} accountId
+ * @returns {Promise<object>}
+ */
+export const deleteAccount = async (accountId) => {
+  const resp = await fetch(`/api/accounts/${accountId}`, {
+    method: 'DELETE',
+  });
+  if (!resp.ok) {
+    const error = await resp.json();
+    throw new Error(error.detail || 'Failed to delete account');
   }
   return resp.json();
 };

--- a/src/penny/static/views/AccountsView.js
+++ b/src/penny/static/views/AccountsView.js
@@ -1,6 +1,6 @@
 import { onMounted } from 'vue/dist/vue.esm-bundler.js';
 
-import { fetchAccounts, updateAccount, recordBalanceSnapshot } from '../api.js';
+import { fetchAccounts, updateAccount, recordBalanceSnapshot, deleteAccount } from '../api.js';
 import { createAccountsViewState } from './accounts.js';
 
 export const AccountsView = {
@@ -14,6 +14,7 @@ export const AccountsView = {
     const {
       accountsList,
       accountsLoading,
+      includeHidden,
       editingAccountId,
       editingAccountData,
       recordingBalanceForId,
@@ -25,10 +26,13 @@ export const AccountsView = {
       startRecordingBalance,
       cancelRecordingBalance,
       saveBalanceSnapshot,
+      hideAccount,
+      toggleIncludeHidden,
     } = createAccountsViewState({
       fetchAccounts,
       updateAccount,
       recordBalanceSnapshot,
+      deleteAccount,
       refreshMeta: props.refreshMeta,
     });
 
@@ -44,6 +48,7 @@ export const AccountsView = {
     return {
       accountsList,
       accountsLoading,
+      includeHidden,
       editingAccountId,
       editingAccountData,
       recordingBalanceForId,
@@ -55,12 +60,25 @@ export const AccountsView = {
       startRecordingBalance,
       cancelRecordingBalance,
       saveBalanceSnapshot,
+      hideAccount,
+      toggleIncludeHidden,
       formatCurrency,
     };
   },
   template: `
     <div>
-      <h2 style="font-size: 1.4rem; margin-bottom: 20px;">Accounts</h2>
+      <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px;">
+        <h2 style="font-size: 1.4rem; margin: 0;">Accounts</h2>
+        <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 0.9rem;">
+          <input
+            type="checkbox"
+            :checked="includeHidden"
+            @change="toggleIncludeHidden"
+            style="cursor: pointer;"
+          >
+          <span>Show Archived</span>
+        </label>
+      </div>
 
       <div v-if="accountsLoading" class="panel" style="padding: 40px; text-align: center;">
         <p style="color: var(--muted);">Loading accounts...</p>
@@ -73,7 +91,12 @@ export const AccountsView = {
       <div v-else style="display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: 16px;">
         <div v-for="acc in accountsList" :key="acc.id"
           :class="['panel', 'account-card', filters.accounts.includes(acc.id) ? 'active' : 'inactive']"
-          style="padding: 24px; transition: all 0.2s;">
+          :style="{
+            padding: '24px',
+            transition: 'all 0.2s',
+            opacity: acc.hidden ? 0.6 : 1,
+            border: acc.hidden ? '2px dashed var(--muted)' : ''
+          }">
 
           <!-- Editing Mode -->
           <div v-if="editingAccountId === acc.id" style="margin-bottom: 16px;">
@@ -208,8 +231,9 @@ export const AccountsView = {
                 {{ filters.accounts.includes(acc.id) ? '💳' : '🔒' }}
               </div>
               <div style="flex: 1; min-width: 0;">
-                <div style="font-weight: 600; font-size: 1rem; margin-bottom: 4px;">
-                  {{ acc.display_name || acc.bank + ' #' + acc.id }}
+                <div style="font-weight: 600; font-size: 1rem; margin-bottom: 4px; display: flex; align-items: center; gap: 8px;">
+                  <span>{{ acc.display_name || acc.bank + ' #' + acc.id }}</span>
+                  <span v-if="acc.hidden" style="font-size: 0.7rem; padding: 2px 8px; background: var(--muted); color: white; border-radius: 4px;">ARCHIVED</span>
                 </div>
                 <div style="font-size: 0.8rem; color: var(--muted); margin-bottom: 4px;">
                   {{ acc.bank }}
@@ -247,6 +271,13 @@ export const AccountsView = {
                 @click="startRecordingBalance(acc)"
                 style="flex: 1; padding: 6px 12px; background: #e8dcc8; border: none; border-radius: 4px; cursor: pointer; font-size: 0.8rem;">
                 💰 Record Balance
+              </button>
+            </div>
+            <div v-if="!acc.hidden" style="display: flex; gap: 8px; margin-top: 8px;">
+              <button
+                @click="hideAccount(acc.id)"
+                style="width: 100%; padding: 6px 12px; background: #d4c4b0; border: none; border-radius: 4px; cursor: pointer; font-size: 0.8rem; color: #6b4a29;">
+                🗄️ Archive Account
               </button>
             </div>
           </div>

--- a/src/penny/static/views/accounts.js
+++ b/src/penny/static/views/accounts.js
@@ -1,8 +1,9 @@
 import { ref } from 'vue/dist/vue.esm-bundler.js';
 
-export const createAccountsViewState = ({ fetchAccounts, updateAccount, recordBalanceSnapshot, refreshMeta }) => {
+export const createAccountsViewState = ({ fetchAccounts, updateAccount, recordBalanceSnapshot, deleteAccount, refreshMeta }) => {
   const accountsList = ref([]);
   const accountsLoading = ref(false);
+  const includeHidden = ref(false);
   const editingAccountId = ref(null);
   const editingAccountData = ref({
     display_name: '',
@@ -20,7 +21,7 @@ export const createAccountsViewState = ({ fetchAccounts, updateAccount, recordBa
   const loadAccounts = async () => {
     accountsLoading.value = true;
     try {
-      const data = await fetchAccounts();
+      const data = await fetchAccounts(includeHidden.value);
       accountsList.value = data.accounts;
     } finally {
       accountsLoading.value = false;
@@ -113,9 +114,28 @@ export const createAccountsViewState = ({ fetchAccounts, updateAccount, recordBa
     }
   };
 
+  const hideAccount = async (accountId) => {
+    if (!confirm('Are you sure you want to hide this account? You can show it again using the "Show Archived" toggle.')) {
+      return;
+    }
+    try {
+      await deleteAccount(accountId);
+      await Promise.all([loadAccounts(), refreshMeta()]);
+    } catch (error) {
+      console.error('Failed to hide account:', error);
+      alert('Failed to hide account: ' + error.message);
+    }
+  };
+
+  const toggleIncludeHidden = async () => {
+    includeHidden.value = !includeHidden.value;
+    await loadAccounts();
+  };
+
   return {
     accountsList,
     accountsLoading,
+    includeHidden,
     editingAccountId,
     editingAccountData,
     recordingBalanceForId,
@@ -127,5 +147,7 @@ export const createAccountsViewState = ({ fetchAccounts, updateAccount, recordBa
     startRecordingBalance,
     cancelRecordingBalance,
     saveBalanceSnapshot,
+    hideAccount,
+    toggleIncludeHidden,
   };
 };


### PR DESCRIPTION
## Summary

Implements the frontend UI components for issue #11. The backend soft-delete functionality was already fully implemented, but the web interface was missing the ability to archive accounts and view archived accounts.

**Key features added:**
- "Archive Account" button with confirmation dialog in the Accounts view
- "Show Archived" toggle checkbox to display/hide archived accounts
- Visual indicators for archived accounts (ARCHIVED badge, reduced opacity, dashed border)
- Updated API client to support `include_hidden` parameter
- Added `deleteAccount()` API function for soft-delete

**Backend integration:**
- The backend DELETE endpoint was already implemented (src/penny/api/accounts.py:138-144)
- Vault mutation log already supports `account_hidden` events
- All filtering and replay functionality was already in place
- This PR completes the feature by adding the missing UI layer

## Test plan

**Manual testing:**
1. Start the Penny application and navigate to Accounts view
2. Verify "Show Archived" toggle appears in the header (unchecked by default)
3. Click "Archive Account" button on any account
4. Confirm the confirmation dialog appears
5. Accept the confirmation and verify:
   - Account disappears from the list (default view)
   - Account is soft-deleted in the database (hidden=1)
   - Mutation logged in mutations.tsv
6. Toggle "Show Archived" checkbox ON
7. Verify archived account reappears with:
   - "ARCHIVED" badge visible
   - Reduced opacity (0.6)
   - Dashed border style
   - No "Archive Account" button (already archived)
8. Verify archived accounts are excluded from transaction filters/reports
9. Toggle "Show Archived" OFF and verify archived accounts disappear again

**CLI verification (already implemented):**
```bash
penny accounts list          # Should not show hidden accounts
penny accounts list --all    # Should show hidden accounts with "hidden" status
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)